### PR TITLE
config to allow apoc.meta functions for backup use

### DIFF
--- a/dev/neo4j.conf
+++ b/dev/neo4j.conf
@@ -275,6 +275,7 @@ dbms.tx_log.rotation.retention_policy=1 days
 # A comma separated list of procedures and user defined functions that are allowed
 # full access to the database through unsupported/insecure internal APIs.
 #dbms.security.procedures.unrestricted=my.extensions.example,my.procedures.*
+dbms.security.procedures.unrestricted=apoc.meta.*
 
 # A comma separated list of procedures to be loaded by default.
 # Leaving this unconfigured will load all procedures found.

--- a/stage/neo4j.conf
+++ b/stage/neo4j.conf
@@ -275,6 +275,7 @@ dbms.tx_log.rotation.retention_policy=1 days
 # A comma separated list of procedures and user defined functions that are allowed
 # full access to the database through unsupported/insecure internal APIs.
 #dbms.security.procedures.unrestricted=my.extensions.example,my.procedures.*
+dbms.security.procedures.unrestricted=apoc.meta.*
 
 # A comma separated list of procedures to be loaded by default.
 # Leaving this unconfigured will load all procedures found.

--- a/test/neo4j.conf
+++ b/test/neo4j.conf
@@ -275,6 +275,7 @@ dbms.tx_log.rotation.retention_policy=1 days
 # A comma separated list of procedures and user defined functions that are allowed
 # full access to the database through unsupported/insecure internal APIs.
 #dbms.security.procedures.unrestricted=my.extensions.example,my.procedures.*
+dbms.security.procedures.unrestricted=apoc.meta.*
 
 # A comma separated list of procedures to be loaded by default.
 # Leaving this unconfigured will load all procedures found.


### PR DESCRIPTION
Need to add a configuration option to allow the use of apoc.meta functions needed to backup schema information.