### PR TITLE
Conf setting to mitigate log4j CVE

### DIFF
--- a/dev/neo4j.conf
+++ b/dev/neo4j.conf
@@ -354,6 +354,9 @@ dbms.jvm.additional=-XX:+DebugNonSafepoints
 # Disable logging JMX endpoint.
 dbms.jvm.additional=-Dlog4j2.disable.jmx=true
 
+# 12/15/2021 - Log4J CVE Mitigation for Neo4j
+dbms.jvm.additional=-Dlog4j2.formatMsgNoLookups=true
+
 #********************************************************************
 # Wrapper Windows NT/2000/XP Service Properties
 #********************************************************************

--- a/localhost/neo4j.conf
+++ b/localhost/neo4j.conf
@@ -354,6 +354,9 @@ dbms.jvm.additional=-XX:+DebugNonSafepoints
 # Disable logging JMX endpoint.
 dbms.jvm.additional=-Dlog4j2.disable.jmx=true
 
+# 12/15/2021 - Log4J CVE Mitigation for Neo4j
+dbms.jvm.additional=-Dlog4j2.formatMsgNoLookups=true
+
 #********************************************************************
 # Wrapper Windows NT/2000/XP Service Properties
 #********************************************************************

--- a/prod/neo4j.conf
+++ b/prod/neo4j.conf
@@ -354,6 +354,9 @@ dbms.jvm.additional=-XX:+DebugNonSafepoints
 # Disable logging JMX endpoint.
 dbms.jvm.additional=-Dlog4j2.disable.jmx=true
 
+# 12/15/2021 - Log4J CVE Mitigation for Neo4j
+dbms.jvm.additional=-Dlog4j2.formatMsgNoLookups=true
+
 #********************************************************************
 # Wrapper Windows NT/2000/XP Service Properties
 #********************************************************************

--- a/stage/neo4j.conf
+++ b/stage/neo4j.conf
@@ -354,6 +354,9 @@ dbms.jvm.additional=-XX:+DebugNonSafepoints
 # Disable logging JMX endpoint.
 dbms.jvm.additional=-Dlog4j2.disable.jmx=true
 
+# 12/15/2021 - Log4J CVE Mitigation for Neo4j
+dbms.jvm.additional=-Dlog4j2.formatMsgNoLookups=true
+
 #********************************************************************
 # Wrapper Windows NT/2000/XP Service Properties
 #********************************************************************

--- a/test/neo4j.conf
+++ b/test/neo4j.conf
@@ -354,6 +354,9 @@ dbms.jvm.additional=-XX:+DebugNonSafepoints
 # Disable logging JMX endpoint.
 dbms.jvm.additional=-Dlog4j2.disable.jmx=true
 
+# 12/15/2021 - Log4J CVE Mitigation for Neo4j
+dbms.jvm.additional=-Dlog4j2.formatMsgNoLookups=true
+
 #********************************************************************
 # Wrapper Windows NT/2000/XP Service Properties
 #********************************************************************


### PR DESCRIPTION
Per suggestion from https://community.neo4j.com/t/log4j-cve-mitigation-for-neo4j/48856

`dbms.jvm.additional=-Dlog4j2.formatMsgNoLookups=true` is already in the neo4j.conf, so just added `dbms.jvm.additional=-Dlog4j2.disable.jmx=true`